### PR TITLE
Changed the default network to `ETH_MAINNET`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,22 @@ import { Network } from 'alchemy-sdk';
 async function main() {
   // Default config to use for all networks.
   const defaultConfig = {
-    apiKey: 'demo', // TODO: Replace with your API key.
-    network: Network.MATIC_MAINNET
+    apiKey: 'demo', // TODO: Replace with your Mainnet Alchemy API key.
+    network: Network.ETH_MAINNET
   };
   // Include optional setting overrides for specific networks.
   const overrides = {
     // TODO: Replace with your API keys.
-    [Network.MATIC_MAINNET]: { apiKey: 'matic-api-key', maxRetries: 10 },
-    [Network.ARB_MAINNET]: { apiKey: 'arb-api-key' }
+    [Network.MATIC_MAINNET]: { apiKey: 'demo', maxRetries: 10 }, // Replace with your Matic Alchemy API key.
+    [Network.ARB_MAINNET]: { apiKey: 'demo' } // Replace with your Arbitrum Alchemy API key.
   };
   const alchemy = new AlchemyMultichainClient(defaultConfig, overrides);
 
   // get NFTs in multiple networks
+  // owner for which you want to get the NFTs
   const owner = '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+
+  // get NFTs for owner in mainnet and matic networks with a page size of 5
   const mainnetNfts = await alchemy
     .forNetwork(Network.ETH_MAINNET)
     .nft.getNftsForOwner(owner, { pageSize: 5 });
@@ -24,6 +27,7 @@ async function main() {
     .forNetwork(Network.MATIC_MAINNET)
     .nft.getNftsForOwner(owner, { pageSize: 5 });
 
+  // log the NFTs
   console.log('mainnetNfts', mainnetNfts);
   console.log('maticNfts', maticNfts);
 }


### PR DESCRIPTION
Changed the default network to `ETH_MAINNET`. It was `MATIC_MAINNET` before, but we're already providing overrides for `MATIC_MAINNET` so it makes sense to change it to `ETH_MAINNET` and added comments to explain the code better.

This is in accordance with the tutorial for [how to manage a multichain project using Alchemy SDK](https://alchemyenterprisegroup.readme.io/reference/how-to-manage-a-multichain-project-using-alchemy-sdk).